### PR TITLE
Correct the unit prefix symbol for unit `kilohash per second`

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const XMR_PORT = 18081;
 export const TARI_PORTS = ["18144", "18146", "18148"];
 export const HASHRATE_UNITS = [
   ["h", "H/s", 1],
-  ["kh", "KH/s", 1000],
+  ["kh", "kH/s", 1000],
   ["mh", "MH/s", 1000000]
 ];
 export const XMR_ADDRESS_RE = /^[48][1-9A-HJ-NP-Za-km-z]{94}([1-9A-HJ-NP-Za-km-z]{11})?$/;

--- a/src/format.js
+++ b/src/format.js
@@ -11,7 +11,7 @@ export function formatNumber(value, digits = 0) {
 export function formatHashrate(value) {
   const number = Number(value);
   if (!isFiniteNumber(number) || number <= 0) return "0 H/s";
-  const units = ["H/s", "KH/s", "MH/s", "GH/s", "TH/s", "PH/s"];
+  const units = ["H/s", "kH/s", "MH/s", "GH/s", "TH/s", "PH/s"];
   let scaled = number;
   let index = 0;
   while (scaled >= 1000 && index < units.length - 1) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -105,7 +105,7 @@ const SRB_RUN_NOTE = "Use --list-devices first if GPU 0 is wrong. Intel Alchemis
 const PROXY_HOSTS_PORT_3333 = "workers connect to this host on port 3333.";
 const REPLACE_PROXY_HOST = "Replace PROXY_HOST with the proxy machine hostname or address.";
 const XMRIG_AUTO_SWITCH_NOTE = "MoneroOcean XMRig benchmarks/switches CPU algos for XMR payout; first run may benchmark for several minutes before pool jobs appear.";
-const SMALL_PROXY_NOTE = "For small proxy setups, start with 64-128 KH/s.";
+const SMALL_PROXY_NOTE = "For small proxy setups, start with 64-128 kH/s.";
 
 export function setupAddress({ queryAddress = "", activeAddress = "", watchlist = [] } = {}) {
   return queryAddress || activeAddress || watchlist.find((row) => row?.address)?.address || DEFAULT_ADDRESS;
@@ -482,7 +482,7 @@ function normalizedHashrateInput(value, fallback) {
 function formatSetupHashrate(hashrateHps) {
   const hps = Number(hashrateHps) || 0;
   if (hps >= 1_000_000) return `${trimFixed(hps / 1_000_000, 3)} MH/s`;
-  if (hps >= 1000) return `${trimFixed(hps / 1000, 3)} KH/s`;
+  if (hps >= 1000) return `${trimFixed(hps / 1000, 3)} kH/s`;
   return `${trimFixed(hps, 3)} H/s`;
 }
 

--- a/src/views/help.js
+++ b/src/views/help.js
@@ -104,10 +104,10 @@ export function referencePortList(ports = DEFAULT_REFERENCE_PORTS) {
 }
 
 function referencePortLabels(ports = DEFAULT_REFERENCE_PORTS) {
-  // Public mining ports are a hashrate ladder: 100xx is KH/s, 11xxx+ is MH/s, and port 80
-  // is a firewall-friendly alias for the first 1 KH/s tier (TLS port = plain + 10000, 443 for 80).
+  // Public mining ports are a hashrate ladder: 100xx is kH/s, 11xxx+ is MH/s, and port 80
+  // is a firewall-friendly alias for the first 1 kH/s tier (TLS port = plain + 10000, 443 for 80).
   return ports.map((port) => {
     const rate = port < 11024 ? port === 80 ? 1 : port - 10000 : (port - 10000) / 1024;
-    return `${port}/${port === 80 ? 443 : port + 10000} TLS for ${rate} ${port < 11024 ? "KH/s" : "MH/s"}`;
+    return `${port}/${port === 80 ? 443 : port + 10000} TLS for ${rate} ${port < 11024 ? "kH/s" : "MH/s"}`;
   });
 }

--- a/tests/core-routing-privacy.mjs
+++ b/tests/core-routing-privacy.mjs
@@ -392,7 +392,7 @@ test.describe("core routing, privacy, and preferences", { concurrency: false }, 
     assert.equal(formatHashrate(0), "0 H/s");
     assert.equal(formatHashrate(-5), "0 H/s");
     assert.equal(formatHashrate(NaN), "0 H/s");
-    assert.equal(formatHashrate(12345), "12.3 KH/s");
+    assert.equal(formatHashrate(12345), "12.3 kH/s");
     assert.equal(formatHashrate(2.5e18), "2500 PH/s");
     assert.equal(escapeHtml(`<a href="x" title='y'>&`), "&lt;a href=&quot;x&quot; title=&#039;y&#039;&gt;&amp;");
     assert.equal(escapeHtml(null), "");

--- a/tests/setup-settings.mjs
+++ b/tests/setup-settings.mjs
@@ -125,12 +125,12 @@ test.describe("setup, settings, uptime, and copy", { concurrency: false }, () =>
       global: [
         { port: 80, tls: false, difficulty: 10000, description: "1 kH/s" },
         { port: 443, tls: true, difficulty: 10000, description: "1 kH/s" },
-        { port: 10001, tls: false, difficulty: 10000, description: "1 KH/s" },
-        { port: 20001, tls: true, difficulty: 10000, description: "1 KH/s" },
-        { port: 10002, tls: false, difficulty: 20000, description: "2 KH/s" },
-        { port: 20002, tls: true, difficulty: 20000, description: "2 KH/s" },
-        { port: 10128, tls: false, difficulty: 1280000, description: "128 KH/s" },
-        { port: 20128, tls: true, difficulty: 1280000, description: "128 KH/s" }
+        { port: 10001, tls: false, difficulty: 10000, description: "1 kH/s" },
+        { port: 20001, tls: true, difficulty: 10000, description: "1 kH/s" },
+        { port: 10002, tls: false, difficulty: 20000, description: "2 kH/s" },
+        { port: 20002, tls: true, difficulty: 20000, description: "2 kH/s" },
+        { port: 10128, tls: false, difficulty: 1280000, description: "128 kH/s" },
+        { port: 20128, tls: true, difficulty: 1280000, description: "128 kH/s" }
       ]
     });
     assert.deepEqual(globalPorts.map((row) => [row.port, row.tlsPort, row.targetHashrate]), [[10001, 20001, 1000], [10002, 20002, 2000], [10128, 20128, 128000]]);
@@ -232,7 +232,7 @@ test.describe("setup, settings, uptime, and copy", { concurrency: false }, () =>
     assert.match(setupPlanWithPorts({ profile: "xmrig-proxy", os: "windows" }).localCommand, /^\.\\xmrig\.exe/);
     assert.match(setupPlanWithPorts({ profile: "xmrig-proxy" }).localCommand, /--nicehash/);
     assert.match(setupPlanWithPorts({ profile: "xmrig-proxy" }).localNote, /Replace PROXY_HOST/);
-    assert.match(setupPlanWithPorts({ profile: "xmrig-proxy" }).notes, /For small proxy setups, start with 64-128 KH\/s/);
+    assert.match(setupPlanWithPorts({ profile: "xmrig-proxy" }).notes, /For small proxy setups, start with 64-128 kH\/s/);
     assert.equal(setupPlanWithPorts({ profile: "xmrig-proxy", algo: "etchash" }).selection.algo, "auto");
     assert.match(setupPlanWithPorts({ profile: "xmr-node-proxy" }).tlsRunCommand, /node proxy\.js --config config\.json/);
     assert.equal(setupPlanWithPorts({ profile: "xmr-node-proxy", algo: "etchash" }).selection.algo, "auto");
@@ -309,9 +309,9 @@ test.describe("setup, settings, uptime, and copy", { concurrency: false }, () =>
   });
 
   test("help reference ports match current port stats", () => {
-    assert.equal(referencePortSummary(), "80/443 TLS for 1 KH/s; 10001/20001 TLS for 1 KH/s; 10002/20002 TLS for 2 KH/s; 10004/20004 TLS for 4 KH/s; 10008/20008 TLS for 8 KH/s; 10016/20016 TLS for 16 KH/s; 10032/20032 TLS for 32 KH/s; 10064/20064 TLS for 64 KH/s; 10128/20128 TLS for 128 KH/s; 10256/20256 TLS for 256 KH/s; 10512/20512 TLS for 512 KH/s; 11024/21024 TLS for 1 MH/s; 12048/22048 TLS for 2 MH/s; 14096/24096 TLS for 4 MH/s; 18192/28192 TLS for 8 MH/s");
+    assert.equal(referencePortSummary(), "80/443 TLS for 1 kH/s; 10001/20001 TLS for 1 kH/s; 10002/20002 TLS for 2 kH/s; 10004/20004 TLS for 4 kH/s; 10008/20008 TLS for 8 kH/s; 10016/20016 TLS for 16 kH/s; 10032/20032 TLS for 32 kH/s; 10064/20064 TLS for 64 kH/s; 10128/20128 TLS for 128 kH/s; 10256/20256 TLS for 256 kH/s; 10512/20512 TLS for 512 kH/s; 11024/21024 TLS for 1 MH/s; 12048/22048 TLS for 2 MH/s; 14096/24096 TLS for 4 MH/s; 18192/28192 TLS for 8 MH/s");
     const list = referencePortList();
-    assert.match(list, /^<ul class="reference-port-list"><li>80\/443 TLS for 1 KH\/s<\/li>/);
+    assert.match(list, /^<ul class="reference-port-list"><li>80\/443 TLS for 1 kH\/s<\/li>/);
     assert.equal([...list.matchAll(/<li>/g)].length, 15);
   });
 


### PR DESCRIPTION
The symbol for `kilo-` is a lowercase `k`, which should never be written in uppercase. The unit prefix symbols are case-sensitive.
